### PR TITLE
Add support for LC_LINKER_OPTION

### DIFF
--- a/MachOKit.xcodeproj/project.pbxproj
+++ b/MachOKit.xcodeproj/project.pbxproj
@@ -969,10 +969,12 @@
 		D0FF4F3A201B0B230095106A /* MKNodeFieldVMProtectionType.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FF4F38201B0B230095106A /* MKNodeFieldVMProtectionType.m */; };
 		D0FF4F3D201B0CD30095106A /* MKNodeFieldTypeSize.h in Headers */ = {isa = PBXBuildFile; fileRef = D0FF4F3B201B0CD30095106A /* MKNodeFieldTypeSize.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0FF4F3E201B0CD30095106A /* MKNodeFieldTypeSize.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FF4F3C201B0CD30095106A /* MKNodeFieldTypeSize.m */; };
+		F37857C724CCD0D9009D37AB /* MKLCLinkerOption.m in Sources */ = {isa = PBXBuildFile; fileRef = F37857C524CCD0D9009D37AB /* MKLCLinkerOption.m */; };
 		F37857F524CCD4CF009D37AB /* load_command_linker_option.c in Sources */ = {isa = PBXBuildFile; fileRef = F37857F324CCD4CF009D37AB /* load_command_linker_option.c */; };
 		F37857F624CCD4CF009D37AB /* load_command_linker_option.c in Sources */ = {isa = PBXBuildFile; fileRef = F37857F324CCD4CF009D37AB /* load_command_linker_option.c */; };
 		F37857F724CCD4CF009D37AB /* load_command_linker_option.h in Headers */ = {isa = PBXBuildFile; fileRef = F37857F424CCD4CF009D37AB /* load_command_linker_option.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F37857F824CCD4CF009D37AB /* load_command_linker_option.h in Headers */ = {isa = PBXBuildFile; fileRef = F37857F424CCD4CF009D37AB /* load_command_linker_option.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F37857F924CCDFE6009D37AB /* MKLCLinkerOption.h in Headers */ = {isa = PBXBuildFile; fileRef = F37857C424CCD0D9009D37AB /* MKLCLinkerOption.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1932,6 +1934,8 @@
 		D0FF4F38201B0B230095106A /* MKNodeFieldVMProtectionType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKNodeFieldVMProtectionType.m; sourceTree = "<group>"; };
 		D0FF4F3B201B0CD30095106A /* MKNodeFieldTypeSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MKNodeFieldTypeSize.h; sourceTree = "<group>"; };
 		D0FF4F3C201B0CD30095106A /* MKNodeFieldTypeSize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKNodeFieldTypeSize.m; sourceTree = "<group>"; };
+		F37857C424CCD0D9009D37AB /* MKLCLinkerOption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MKLCLinkerOption.h; sourceTree = "<group>"; };
+		F37857C524CCD0D9009D37AB /* MKLCLinkerOption.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKLCLinkerOption.m; sourceTree = "<group>"; };
 		F37857F324CCD4CF009D37AB /* load_command_linker_option.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_command_linker_option.c; sourceTree = "<group>"; };
 		F37857F424CCD4CF009D37AB /* load_command_linker_option.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = load_command_linker_option.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3408,6 +3412,8 @@
 				D0399E4E23D511850055C2D4 /* MKLCDyldExportsTrie.m */,
 				D0399E5123D5124E0055C2D4 /* MKLCDyldChainedFixups.h */,
 				D0399E5223D5124E0055C2D4 /* MKLCDyldChainedFixups.m */,
+				F37857C424CCD0D9009D37AB /* MKLCLinkerOption.h */,
+				F37857C524CCD0D9009D37AB /* MKLCLinkerOption.m */,
 			);
 			name = "Load Commands";
 			path = Load_Commands;
@@ -3588,6 +3594,7 @@
 				D0399E5E23D643F00055C2D4 /* exports_trie_internal.h in Headers */,
 				D0B16D611CA8968900E2116C /* MKIndirectSymbolTable.h in Headers */,
 				D0678A49225977D9007E0C8E /* load_command_lazy_load_dylib.h in Headers */,
+				F37857F924CCDFE6009D37AB /* MKLCLinkerOption.h in Headers */,
 				D01731751C671891007CB0A1 /* MKDSCSlideInfo.h in Headers */,
 				D01B986F1B768ECC0035F464 /* MKDSCStringTable.h in Headers */,
 				D0CC85841C6FBBEF001FB7C7 /* MKDSCImagesInfo.h in Headers */,
@@ -4498,6 +4505,7 @@
 				D01C751A1CA74AC100648CA6 /* MKBindDoBindAddAddressULEB.m in Sources */,
 				D0995A121A6B8DC9007134CE /* MKIndirectSymbol.m in Sources */,
 				D0F6B50F21DAA7E10040E72D /* MKStaticSymbol.m in Sources */,
+				F37857C724CCD0D9009D37AB /* MKLCLinkerOption.m in Sources */,
 				D030304D1A23CEB200288B3E /* MKLCRPath.m in Sources */,
 				D0B16D491CA8503800E2116C /* MKWeakBindingsInfo.m in Sources */,
 				D0A1D84D19E4EE480095870C /* memory_object.c in Sources */,

--- a/MachOKit.xcodeproj/project.pbxproj
+++ b/MachOKit.xcodeproj/project.pbxproj
@@ -969,6 +969,10 @@
 		D0FF4F3A201B0B230095106A /* MKNodeFieldVMProtectionType.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FF4F38201B0B230095106A /* MKNodeFieldVMProtectionType.m */; };
 		D0FF4F3D201B0CD30095106A /* MKNodeFieldTypeSize.h in Headers */ = {isa = PBXBuildFile; fileRef = D0FF4F3B201B0CD30095106A /* MKNodeFieldTypeSize.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0FF4F3E201B0CD30095106A /* MKNodeFieldTypeSize.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FF4F3C201B0CD30095106A /* MKNodeFieldTypeSize.m */; };
+		F37857F524CCD4CF009D37AB /* load_command_linker_option.c in Sources */ = {isa = PBXBuildFile; fileRef = F37857F324CCD4CF009D37AB /* load_command_linker_option.c */; };
+		F37857F624CCD4CF009D37AB /* load_command_linker_option.c in Sources */ = {isa = PBXBuildFile; fileRef = F37857F324CCD4CF009D37AB /* load_command_linker_option.c */; };
+		F37857F724CCD4CF009D37AB /* load_command_linker_option.h in Headers */ = {isa = PBXBuildFile; fileRef = F37857F424CCD4CF009D37AB /* load_command_linker_option.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F37857F824CCD4CF009D37AB /* load_command_linker_option.h in Headers */ = {isa = PBXBuildFile; fileRef = F37857F424CCD4CF009D37AB /* load_command_linker_option.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1928,6 +1932,8 @@
 		D0FF4F38201B0B230095106A /* MKNodeFieldVMProtectionType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKNodeFieldVMProtectionType.m; sourceTree = "<group>"; };
 		D0FF4F3B201B0CD30095106A /* MKNodeFieldTypeSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MKNodeFieldTypeSize.h; sourceTree = "<group>"; };
 		D0FF4F3C201B0CD30095106A /* MKNodeFieldTypeSize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKNodeFieldTypeSize.m; sourceTree = "<group>"; };
+		F37857F324CCD4CF009D37AB /* load_command_linker_option.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_command_linker_option.c; sourceTree = "<group>"; };
+		F37857F424CCD4CF009D37AB /* load_command_linker_option.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = load_command_linker_option.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2304,6 +2310,8 @@
 		D036504219DA732100418D1D /* Load Commands */ = {
 			isa = PBXGroup;
 			children = (
+				F37857F324CCD4CF009D37AB /* load_command_linker_option.c */,
+				F37857F424CCD4CF009D37AB /* load_command_linker_option.h */,
 				D0A1D86019E4EEB80095870C /* _load_command_dyld_info.h */,
 				D0A1D85F19E4EEB80095870C /* _load_command_dyld_info.c */,
 				D0A1D86219E4EEB80095870C /* _load_command_dylib.h */,
@@ -3736,6 +3744,7 @@
 				D05F8A7E21DAF4750094F805 /* MKObjectFileNameSymbol.h in Headers */,
 				D0A1D84219E4EE170095870C /* core.h in Headers */,
 				D010F7201CB8710F004025F5 /* MKObjCClassReferencesSection.h in Headers */,
+				F37857F724CCD4CF009D37AB /* load_command_linker_option.h in Headers */,
 				D010F7141CB87019004025F5 /* MKObjCConstSection.h in Headers */,
 				D06D59AA20151F7500A99173 /* MKBooleanFormatter.h in Headers */,
 				D04269E51DD931E40091AB2A /* MKPtr.h in Headers */,
@@ -3988,6 +3997,7 @@
 				D0A3BBDA1A68ECBF00D663A0 /* load_command_symtab.h in Headers */,
 				D0A3BBCA1A68ECBF00D663A0 /* load_command_rpath.h in Headers */,
 				D017179A1A99607700F234EF /* indirect_symbol_table.h in Headers */,
+				F37857F824CCD4CF009D37AB /* load_command_linker_option.h in Headers */,
 				D0848AE41A959E390076976F /* symbol_table.h in Headers */,
 				D0A3BB8E1A68EC9D00D663A0 /* macho_image.h in Headers */,
 				D02C80921F907F8C00EB9393 /* load_command_note.h in Headers */,
@@ -4505,6 +4515,7 @@
 				D0995A2A1A6C914D007134CE /* MKFatArch.m in Sources */,
 				D06D596F2013BB6700A99173 /* MKNodeFieldMachOFileType.m in Sources */,
 				D0B16D641CA8968900E2116C /* MKStringTable.m in Sources */,
+				F37857F524CCD4CF009D37AB /* load_command_linker_option.c in Sources */,
 				D06CEC5322629736001FF343 /* MKBindThreaded.m in Sources */,
 				D096B04E201C2EFF003DA008 /* MKNodeFieldSectionFlagsType.m in Sources */,
 				D0539BA91A23D28400D3A5F0 /* MKLCVersionMinMacOSX.m in Sources */,
@@ -4717,6 +4728,7 @@
 				D0A3BBA11A68ECBF00D663A0 /* _load_command_linkedit.c in Sources */,
 				D0A3BB811A68EC8600D663A0 /* macho_image.c in Sources */,
 				D0A3BBDD1A68ECBF00D663A0 /* load_command_twolevel_hints.c in Sources */,
+				F37857F624CCD4CF009D37AB /* load_command_linker_option.c in Sources */,
 				D0A3BBD51A68ECBF00D663A0 /* load_command_sub_client.c in Sources */,
 				D0399E5C23D643D60055C2D4 /* exports_trie.c in Sources */,
 				D0A3BBC31A68ECBF00D663A0 /* load_command_prebind_cksum.c in Sources */,

--- a/MachOKit/Load_Commands/MKLCLinkerOption.h
+++ b/MachOKit/Load_Commands/MKLCLinkerOption.h
@@ -1,0 +1,51 @@
+//----------------------------------------------------------------------------//
+//|
+//|             MachOKit - A Lightweight Mach-O Parsing Library
+//! @file       MKLCLinkerOption.h
+//!
+//! @author     Milen Dzhumerov
+//! @copyright  Copyright (c) 2020-2020 Milen Dzhumerov. All rights reserved.
+//|
+//| Permission is hereby granted, free of charge, to any person obtaining a
+//| copy of this software and associated documentation files (the "Software"),
+//| to deal in the Software without restriction, including without limitation
+//| the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//| and/or sell copies of the Software, and to permit persons to whom the
+//| Software is furnished to do so, subject to the following conditions:
+//|
+//| The above copyright notice and this permission notice shall be included
+//| in all copies or substantial portions of the Software.
+//|
+//| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//| OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//| MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//| IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//| CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//| TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//| SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------//
+
+#import <MachOKit/MachOKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+//----------------------------------------------------------------------------//
+//! Parser for \c LC_LINKER_OPTION.
+//!
+//! The linker_option_command contains a list of flags that will be passed to
+//! to the linker when linking an object file.
+//
+@interface MKLCLinkerOption : MKLoadCommand {
+@package
+  uint32_t _nstrings;
+  NSArray<MKCString *> *_strings;
+}
+
+@property (nonatomic, readonly) NSArray<MKCString*> *strings;
+
+//! Number of strings
+@property (nonatomic, readonly) uint32_t nstrings;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MachOKit/Load_Commands/MKLCLinkerOption.m
+++ b/MachOKit/Load_Commands/MKLCLinkerOption.m
@@ -59,7 +59,7 @@
                 NSError *stringError = nil;
                 MKCString *string = [[MKCString alloc] initWithOffset:offset fromParent:self error:&stringError];
                 if (string == nil) {
-                    MK_PUSH_UNDERLYING_WARNING(strings, stringError, @"Failed to instantiate build tool version at index " PRIi32 "", (self.nstrings - stringCount));
+                    MK_PUSH_UNDERLYING_WARNING(strings, stringError, @"Failed to read string at index " PRIi32 "", (self.nstrings - (stringCount + 1 /** as already decremented */)));
                     break;
                 }
                 

--- a/MachOKit/Load_Commands/MKLCLinkerOption.m
+++ b/MachOKit/Load_Commands/MKLCLinkerOption.m
@@ -1,0 +1,122 @@
+//----------------------------------------------------------------------------//
+//|
+//|             MachOKit - A Lightweight Mach-O Parsing Library
+//|             MKLCLinkerOption.m
+//|
+//|             Milen Dzhumerov
+//|             Copyright (c) 2020-2020 Milen Dzhumerov. All rights reserved.
+//|
+//| Permission is hereby granted, free of charge, to any person obtaining a
+//| copy of this software and associated documentation files (the "Software"),
+//| to deal in the Software without restriction, including without limitation
+//| the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//| and/or sell copies of the Software, and to permit persons to whom the
+//| Software is furnished to do so, subject to the following conditions:
+//|
+//| The above copyright notice and this permission notice shall be included
+//| in all copies or substantial portions of the Software.
+//|
+//| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//| OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//| MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//| IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//| CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//| TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//| SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------//
+
+#import "MKLCLinkerOption.h"
+
+@implementation MKLCLinkerOption
+
+@synthesize nstrings = _nstrings;
+@synthesize strings = _strings;
+
+//|++++++++++++++++++++++++++++++++++++|//
++ (uint32_t)ID
+{ return LC_LINKER_OPTION; }
+
+//|++++++++++++++++++++++++++++++++++++|//
+- (instancetype)initWithOffset:(mk_vm_offset_t)offset fromParent:(MKBackedNode*)parent error:(NSError**)error
+{
+    self = [super initWithOffset:offset fromParent:parent error:error];
+    if (self == nil) return nil;
+    
+    struct linker_option_command lc;
+    if ([self.memoryMap copyBytesAtOffset:offset fromAddress:parent.nodeContextAddress into:&lc length:sizeof(lc) requireFull:YES error:error] < sizeof(lc))
+    { [self release]; return nil; }
+    
+    _nstrings = MKSwapLValue32(lc.count, self.macho.dataModel);
+    
+    {
+        uint32_t stringCount = self.nstrings;
+        NSMutableArray<MKCString *> *strings = [[NSMutableArray alloc] initWithCapacity:stringCount];
+        mach_vm_offset_t offset = sizeof(lc);
+        
+        while (stringCount--) {
+            @autoreleasepool {
+                
+                NSError *stringError = nil;
+                MKCString *string = [[MKCString alloc] initWithOffset:offset fromParent:self error:&stringError];
+                if (string == nil) {
+                    MK_PUSH_UNDERLYING_WARNING(strings, stringError, @"Failed to instantiate build tool version at index " PRIi32 "", (self.nstrings - stringCount));
+                    break;
+                }
+                
+                if (string.nodeSize < 1) {
+                    MK_PUSH_WARNING(strings, MK_EINVALID_DATA, @"String needs to contain at least terminating NULL char");
+                    break;
+                }
+                
+                
+                offset += string.nodeSize;
+                
+                [strings addObject:string];
+                [string release];
+            }
+        }
+        
+        _strings = [strings copy];
+        [strings release];
+    }
+    
+    return self;
+}
+
+//|++++++++++++++++++++++++++++++++++++|//
++ (uint32_t)canInstantiateWithLoadCommandID:(uint32_t)commandID
+{
+    if (self != MKLCLinkerOption.class)
+        return 0;
+    
+    return commandID == [self ID] ? 10 : 0;
+}
+
+//|++++++++++++++++++++++++++++++++++++|//
+- (MKNodeDescription*)layout
+{
+    __unused struct linker_option_command loc;
+    
+    MKNodeFieldBuilder *nstrings = [MKNodeFieldBuilder
+                                    builderWithProperty:MK_PROPERTY(nstrings)
+                                    type:MKNodeFieldTypeUnsignedDoubleWord.sharedInstance
+                                    offset:offsetof(typeof(loc), count)
+                                    size:sizeof(loc.count)
+                                    ];
+    nstrings.description = @"Number Of Strings";
+    nstrings.options = MKNodeFieldOptionDisplayAsDetail;
+    
+    MKNodeFieldBuilder *strings = [MKNodeFieldBuilder
+                                   builderWithProperty:MK_PROPERTY(strings)
+                                   type:[MKNodeFieldTypeCollection typeWithCollectionType:[MKNodeFieldTypeNode typeWithNodeType:MKCString.class]]
+                                   ];
+    strings.description = @"Strings";
+    strings.options = MKNodeFieldOptionDisplayAsDetail | MKNodeFieldOptionMergeWithParent;
+    
+    return [MKNodeDescription nodeDescriptionWithParentDescription:super.layout fields:@[
+        nstrings.build,
+        strings.build,
+    ]];
+}
+
+@end

--- a/MachOKit/MachOKit.h
+++ b/MachOKit/MachOKit.h
@@ -133,6 +133,7 @@
     #import <MachOKit/MKLCBuildVersion.h>
     #import <MachOKit/MKLCDyldExportsTrie.h>
     #import <MachOKit/MKLCDyldChainedFixups.h>
+    #import <MachOKit/MKLCLinkerOption.h>
 #import <MachOKit/MKMachO+Libraries.h>
     #import <MachOKit/MKDependentLibrary.h>
 #import <MachOKit/MKMachO+Segments.h>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -144,7 +144,6 @@ Mach-O Kit currently supports executables, dynamic shared libraries (dylibs and 
         * LC_PREPAGE
         * LC_PREBOUND_DYLIB
         * LC_SUB_UMBRELLA
-        * LC_LINKER_OPTION
         * LC_LINKER_OPTIMIZATION_HINT
     * Segments and Sections ✔
         * Strings Section ✔

--- a/Tests/Specs/libMachO/macho_load_command_spec.m
+++ b/Tests/Specs/libMachO/macho_load_command_spec.m
@@ -83,12 +83,12 @@ SpecBegin(macho_load_command)
                 expect(copy_result).to.equal(0);
             });
             
-            it(@"fails to copy to small buffer", ^{
-                char buffer[4];
+            it(@"partial copy to small buffer", ^{
+                char buffer[7];
                 size_t copy_result = mk_load_command_linker_option_copy_string(load_command, 0, buffer, sizeof(buffer));
-                expect(copy_result).to.equal(0);
-                copy_result = mk_load_command_linker_option_copy_string(load_command, 1, buffer, sizeof(buffer));
-                expect(copy_result).to.equal(0);
+                expect(copy_result).to.equal(6 /* # chars without NULL char */);
+                int cmp_result = strncmp(buffer, "-frame", MIN(sizeof(buffer), strlen("-frame") + 1));
+                expect(cmp_result).to.equal(0);
             });
             
             it(@"copies description", ^{
@@ -127,6 +127,17 @@ SpecBegin(macho_load_command)
                 });
                 
                 expect(count).to.equal(1);
+            });
+            
+            it(@"returns required buffer size", ^{
+                size_t string_length = mk_load_command_linker_option_copy_string(load_command, 0, NULL, 0);
+                expect(string_length).notTo.equal(0);
+                size_t buffer_size = string_length + 1 /* NULL char */;
+                char *buffer = malloc(buffer_size);
+                size_t actual_string_length = mk_load_command_linker_option_copy_string(load_command, 0, buffer, buffer_size);
+                expect(actual_string_length).to.equal(string_length);
+                expect(strncmp(buffer, "-framework", buffer_size)).to.equal(0);
+                free(buffer);
             });
         });
         

--- a/Tests/Specs/libMachO/macho_load_command_spec.m
+++ b/Tests/Specs/libMachO/macho_load_command_spec.m
@@ -106,7 +106,7 @@ SpecBegin(macho_load_command)
             
             it(@"enumerates using block", ^{
                 __block uint32_t count = 0;
-                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, char *__unused stop) {
+                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, bool *__unused stop) {
                     const char *expected_string = (index == 0 ? "-framework" : "CoreFoundation");
                     int cmp = strcmp(string, expected_string);
                     expect(cmp).to.equal(0);
@@ -118,7 +118,7 @@ SpecBegin(macho_load_command)
             
             it(@"enumerates using block with stop", ^{
                 __block uint32_t count = 0;
-                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, char *__unused stop) {
+                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, bool *__unused stop) {
                     int cmp = strcmp(string, "-framework");
                     expect(cmp).to.equal(0);
                     expect(index).to.equal(0);

--- a/Tests/Specs/libMachO/macho_load_command_spec.m
+++ b/Tests/Specs/libMachO/macho_load_command_spec.m
@@ -5,6 +5,7 @@
 //|
 //|             D.V.
 //|             Copyright (c) 2014-2015 D.V. All rights reserved.
+//|             Copyright (c) 2020-2020 Milen Dzhumerov. All rights reserved.
 //|
 //| Permission is hereby granted, free of charge, to any person obtaining a
 //| copy of this software and associated documentation files (the "Software"),
@@ -30,6 +31,180 @@ SpecBegin(macho_load_command)
     mk_memory_map_self_t *memory_map = malloc(sizeof(*memory_map));
     mk_error_t err = mk_memory_map_self_init(NULL, memory_map);
     if (err != MK_ESUCCESS) return;
+
+    #define FRAMEWORK_PARAM_STRING "-framework"
+    #define CORE_FOUNDATION_STRING "CoreFoundation"
+    
+    describe(@"LC_LINKER_OPTION", ^{
+        describe(@"with valid command", ^{
+            struct _dummy {
+                struct mach_header_64 header;
+                struct {
+                    struct __attribute__((packed)) {
+                        struct linker_option_command cmd;
+                        char framework_param[sizeof(FRAMEWORK_PARAM_STRING)];
+                        char cf_param[sizeof(CORE_FOUNDATION_STRING)];
+                    } lc_linker_option;
+                } commands;
+            };
+            struct _dummy *dummy = malloc(sizeof(*dummy));
+            
+            struct mach_header_64 *header = &dummy->header;
+            header->magic = MH_MAGIC_64;
+            header->filetype = MH_EXECUTE;
+            header->sizeofcmds = sizeof(dummy->commands);
+            
+            struct linker_option_command *lc_linker_option = &dummy->commands.lc_linker_option.cmd;
+            lc_linker_option->cmd = LC_LINKER_OPTION;
+            lc_linker_option->cmdsize = sizeof(dummy->commands.lc_linker_option);
+            lc_linker_option->count = 2;
+            snprintf(dummy->commands.lc_linker_option.framework_param, sizeof(dummy->commands.lc_linker_option.framework_param), FRAMEWORK_PARAM_STRING);
+            snprintf(dummy->commands.lc_linker_option.cf_param, sizeof(dummy->commands.lc_linker_option.cf_param), CORE_FOUNDATION_STRING);
+            
+            mk_macho_t *macho = malloc(sizeof(*macho));
+            NSParameterAssert(mk_macho_init_with_slide(NULL, "Test", 0, (mk_vm_address_t)dummy, memory_map, macho) == MK_ESUCCESS);
+            mk_load_command_t *load_command = malloc(sizeof(*load_command));
+            NSParameterAssert(mk_load_command_init(macho, (struct load_command*)&dummy->commands.lc_linker_option, load_command) == MK_ESUCCESS);
+            
+            it(@"gets number of strings", ^{
+                uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
+                expect(nstrings).to.equal(2);
+            });
+            
+            it(@"copies strings", ^{
+                char buffer[512];
+                bzero(buffer, sizeof(buffer));
+                size_t copy_result = mk_load_command_linker_option_copy_string(load_command, 0, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(strlen(FRAMEWORK_PARAM_STRING));
+                copy_result = mk_load_command_linker_option_copy_string(load_command, 1, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(strlen(CORE_FOUNDATION_STRING));
+                // request out of bounds of index
+                copy_result = mk_load_command_linker_option_copy_string(load_command, 2, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(0);
+            });
+            
+            it(@"fails to copy to small buffer", ^{
+                char buffer[4];
+                size_t copy_result = mk_load_command_linker_option_copy_string(load_command, 0, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(0);
+                copy_result = mk_load_command_linker_option_copy_string(load_command, 1, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(0);
+            });
+            
+            it(@"copies description", ^{
+                char description_buffer[512];
+                bzero(description_buffer, sizeof(description_buffer));
+                size_t copy_result = mk_type_copy_description(load_command, description_buffer, sizeof(description_buffer));
+                expect(copy_result).notTo.equal(0);
+                
+                char expected_buffer[512];
+                snprintf(expected_buffer, sizeof(expected_buffer), "<LC_LINKER_OPTION %p> {\n\t-framework\n\tCoreFoundation\n}", load_command);
+                
+                int cmp = strcmp(description_buffer, expected_buffer);
+                expect(cmp).to.equal(0);
+            });
+            
+            it(@"enumerates using block", ^{
+                __block uint32_t count = 0;
+                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, char *__unused stop) {
+                    const char *expected_string = (index == 0 ? "-framework" : "CoreFoundation");
+                    int cmp = strcmp(string, expected_string);
+                    expect(cmp).to.equal(0);
+                    ++count;
+                });
+                
+                expect(count).to.equal(2);
+            });
+            
+            it(@"enumerates using block with stop", ^{
+                __block uint32_t count = 0;
+                mk_load_command_linker_option_enumerate_strings(load_command, ^(const char *string, uint32_t index, char *__unused stop) {
+                    int cmp = strcmp(string, "-framework");
+                    expect(cmp).to.equal(0);
+                    expect(index).to.equal(0);
+                    ++count;
+                    *stop = true;
+                });
+                
+                expect(count).to.equal(1);
+            });
+        });
+        
+        describe(@"with invalid string count", ^{
+            struct _dummy {
+                struct mach_header_64 header;
+                struct {
+                    struct __attribute__((packed)) {
+                        struct linker_option_command cmd;
+                        char framework_param[sizeof(FRAMEWORK_PARAM_STRING)];
+                        char cf_param[sizeof(CORE_FOUNDATION_STRING)];
+                    } lc_linker_option;
+                } commands;
+            };
+            struct _dummy *dummy = malloc(sizeof(*dummy));
+            
+            struct mach_header_64 *header = &dummy->header;
+            header->magic = MH_MAGIC_64;
+            header->filetype = MH_EXECUTE;
+            header->sizeofcmds = sizeof(dummy->commands);
+            
+            struct linker_option_command *lc_linker_option = &dummy->commands.lc_linker_option.cmd;
+            lc_linker_option->cmd = LC_LINKER_OPTION;
+            lc_linker_option->cmdsize = sizeof(dummy->commands.lc_linker_option);
+            // Declared string count larger than actual number of strings (2)
+            lc_linker_option->count = 3;
+            snprintf(dummy->commands.lc_linker_option.framework_param, sizeof(dummy->commands.lc_linker_option.framework_param), FRAMEWORK_PARAM_STRING);
+            snprintf(dummy->commands.lc_linker_option.cf_param, sizeof(dummy->commands.lc_linker_option.cf_param), CORE_FOUNDATION_STRING);
+            
+            mk_macho_t *macho = malloc(sizeof(*macho));
+            NSParameterAssert(mk_macho_init_with_slide(NULL, "Test", 0, (mk_vm_address_t)dummy, memory_map, macho) == MK_ESUCCESS);
+            mk_load_command_t *load_command = malloc(sizeof(*load_command));
+            NSParameterAssert(mk_load_command_init(macho, (struct load_command*)&dummy->commands.lc_linker_option, load_command) == MK_ESUCCESS);
+            
+            it(@"handles out of bounds string", ^{
+                char buffer[512];
+                size_t copy_result = mk_load_command_linker_option_copy_string(load_command, 2, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(0);
+            });
+        });
+        
+        describe(@"with non-null terminated string", ^{
+            struct _dummy {
+                struct mach_header_64 header;
+                struct {
+                    struct __attribute__((packed)) {
+                        struct linker_option_command cmd;
+                        char string[16];
+                    } lc_linker_option;
+                } commands;
+            };
+            struct _dummy *dummy = malloc(sizeof(*dummy));
+            
+            struct mach_header_64 *header = &dummy->header;
+            header->magic = MH_MAGIC_64;
+            header->filetype = MH_EXECUTE;
+            header->sizeofcmds = sizeof(dummy->commands);
+            
+            struct linker_option_command *lc_linker_option = &dummy->commands.lc_linker_option.cmd;
+            // Fill whole command with 'a' chars _without_ a terminating NULL char
+            memset(&dummy->commands.lc_linker_option, 'a', sizeof(struct linker_option_command));
+            
+            lc_linker_option->cmd = LC_LINKER_OPTION;
+            lc_linker_option->cmdsize = sizeof(dummy->commands.lc_linker_option);
+            lc_linker_option->count = 1;
+            
+            mk_macho_t *macho = malloc(sizeof(*macho));
+            NSParameterAssert(mk_macho_init_with_slide(NULL, "Test", 0, (mk_vm_address_t)dummy, memory_map, macho) == MK_ESUCCESS);
+            mk_load_command_t *load_command = malloc(sizeof(*load_command));
+            NSParameterAssert(mk_load_command_init(macho, (struct load_command*)&dummy->commands.lc_linker_option, load_command) == MK_ESUCCESS);
+            
+            it(@"correctly fails to copy string", ^{
+                char buffer[512];
+                size_t copy_result = mk_load_command_linker_option_copy_string(load_command, 0, buffer, sizeof(buffer));
+                expect(copy_result).to.equal(0);
+            });
+        });
+    });
     
     //------------------------------------------------------------------------//
     describe(@"LC_ID_DYLINKER", ^{

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
@@ -146,7 +146,7 @@ mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint
 #if __BLOCKS__
 void
 mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
-                                              void (^enumerator)(const char* string, uint32_t index, bool* stop))
+                                              void (^enumerator)(const char *string, uint32_t index, bool *stop))
 {
     uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
     if (nstrings == UINT32_MAX || enumerator == NULL) {

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
@@ -146,7 +146,7 @@ mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint
 #if __BLOCKS__
 void
 mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
-                                              void (^enumerator)(const char* string, uint32_t index, char* stop))
+                                              void (^enumerator)(const char* string, uint32_t index, bool* stop))
 {
     uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
     if (nstrings == UINT32_MAX || enumerator == NULL) {
@@ -156,7 +156,7 @@ mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command
     for (uint32_t i = 0; i < nstrings; ++i) {
         const char *string = mk_load_command_linker_option_get_string(load_command, i, NULL);
         if (string != NULL) {
-            char stop = false;
+            bool stop = false;
             enumerator(string, i, &stop);
             if (stop) {
                 break;

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
@@ -89,9 +89,6 @@ mk_load_command_linker_option_get_nstrings(mk_load_command_ref load_command)
 
 static const char*
 mk_load_command_linker_option_get_string(mk_load_command_ref load_command, uint32_t requested_index, size_t *string_length) {
-    _MK_LOAD_COMMAND_NOT_NULL(load_command, return NULL);
-    _MK_LOAD_COMMAND_IS_A(load_command, _mk_load_command_linker_option_class, return NULL);
-    
     uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
     if (nstrings == UINT32_MAX || requested_index >= nstrings) {
         return NULL;

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
@@ -131,12 +131,15 @@ mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint
     size_t current_string_len = 0;
     const char *current_option_start = mk_load_command_linker_option_get_string(load_command, requested_index, &current_string_len);
     
-    if (current_option_start != NULL && (current_string_len + 1 /* NULL char */) <= output_len) {
-        memcpy(output, current_option_start, current_string_len + 1 /* NULL char */);
-        return current_string_len;
+    if (output != NULL && output_len > 0) {
+        size_t bytes_to_copy = MIN(current_string_len, output_len - 1 /* NULL char */);
+        memcpy(output, current_option_start, bytes_to_copy);
+        output[bytes_to_copy] = '\0';
+        
+        return bytes_to_copy;
     }
     
-    return 0;
+    return current_string_len;
 }
 
 //|++++++++++++++++++++++++++++++++++++|//

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.c
@@ -1,0 +1,167 @@
+//----------------------------------------------------------------------------//
+//|
+//|             MachOKit - A Lightweight Mach-O Parsing Library
+//|             load_command_build_version.c
+//|
+//|             Milen Dzhumerov
+//|             Copyright (c) 2020-2020 Milen Dzhumerov. All rights reserved.
+//|
+//| Permission is hereby granted, free of charge, to any person obtaining a
+//| copy of this software and associated documentation files (the "Software"),
+//| to deal in the Software without restriction, including without limitation
+//| the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//| and/or sell copies of the Software, and to permit persons to whom the
+//| Software is furnished to do so, subject to the following conditions:
+//|
+//| The above copyright notice and this permission notice shall be included
+//| in all copies or substantial portions of the Software.
+//|
+//| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//| OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//| MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//| IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//| CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//| TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//| SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------//
+
+#include "macho_abi_internal.h"
+
+//|++++++++++++++++++++++++++++++++++++|//
+static size_t
+_mk_load_command_linker_option_copy_description(__unused mk_load_command_ref load_command, char *output, size_t output_len)
+{
+    char all_options_buffer[512];
+    bzero(all_options_buffer, sizeof(all_options_buffer));
+    
+    // invariant:
+    //   - chars at "strings_length" and beyond are all NULL
+    //   - chars at indexes less than "strings_length" are non-NULL
+    //   - strings_length < sizeof(description_buffer)
+    size_t strings_length = 0;
+    uint32_t num_strings = mk_load_command_linker_option_get_nstrings(load_command);
+    if (num_strings == UINT32_MAX) {
+        return 0;
+    }
+    
+    for (uint32_t i = 0; i < num_strings; ++i) {
+        char current_option_buffer[512];
+        size_t copy_result = mk_load_command_linker_option_copy_string(load_command, i, current_option_buffer, sizeof(current_option_buffer));
+        if (copy_result == 0) {
+            return 0;
+        }
+        
+        size_t remaining_length = sizeof(all_options_buffer) - strings_length;
+        size_t char_count = (size_t)snprintf(&all_options_buffer[strings_length], remaining_length, "\t%s\n", current_option_buffer);
+        if (char_count + 1 /* NULL char */ > remaining_length) {
+            return 0;
+        }
+        
+        strings_length += char_count; // point at the first NULL char
+    }
+    
+    return (size_t)snprintf(output, output_len, "<%s %p> {\n%s}",
+                                mk_type_name(load_command.type), load_command.type,
+                                all_options_buffer);
+}
+
+const struct _mk_load_command_vtable _mk_load_command_linker_option_class = {
+    .base.super                 = &_mk_load_command_class,
+    .base.name                  = "LC_LINKER_OPTION",
+    .base.copy_description      = &_mk_load_command_linker_option_copy_description,
+    .command_id                 = LC_LINKER_OPTION,
+    .command_base_size          = sizeof(struct linker_option_command)
+};
+
+//|++++++++++++++++++++++++++++++++++++|//
+uint32_t mk_load_command_linker_option_id()
+{ return LC_LINKER_OPTION; }
+
+uint32_t
+mk_load_command_linker_option_get_nstrings(mk_load_command_ref load_command)
+{
+    _MK_LOAD_COMMAND_NOT_NULL(load_command, return UINT32_MAX);
+    _MK_LOAD_COMMAND_IS_A(load_command, _mk_load_command_linker_option_class, return UINT32_MAX);
+    
+    struct linker_option_command *linker_option_command = (struct linker_option_command*)load_command.load_command->mach_load_command;
+    return mk_macho_get_byte_order(load_command.load_command->image)->swap32( linker_option_command->count );
+}
+
+static const char*
+mk_load_command_linker_option_get_string(mk_load_command_ref load_command, uint32_t requested_index, size_t *string_length) {
+    _MK_LOAD_COMMAND_NOT_NULL(load_command, return NULL);
+    _MK_LOAD_COMMAND_IS_A(load_command, _mk_load_command_linker_option_class, return NULL);
+    
+    uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
+    if (nstrings == UINT32_MAX || requested_index >= nstrings) {
+        return NULL;
+    }
+
+    struct linker_option_command *linker_option_command = (struct linker_option_command*)load_command.load_command->mach_load_command;
+    char *command_end = ((char*)linker_option_command) + linker_option_command->cmdsize;
+    char *current_option = ((char*)linker_option_command) + sizeof(struct linker_option_command);
+    uint32_t current_index = 0;
+    
+    while (current_index <= requested_index && current_option < command_end) {
+        size_t max_len = (size_t)(command_end - current_option);
+        size_t current_string_len = strnlen(current_option, max_len);
+        if (current_string_len == max_len) {
+            // By the command spec, all strings must be NULL terminated
+            return NULL;
+        }
+        
+        if (current_index == requested_index) {
+            if (string_length) {
+                *string_length = current_string_len;
+            }
+            return current_option;
+        }
+        
+        ++current_index;
+        current_option += current_string_len + 1 /* NULL char */;
+    }
+    
+    // Last processed NULL-terminated string ends exactly at the command end
+    return NULL;
+}
+
+size_t
+mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint32_t requested_index, char *output, size_t output_len)
+{
+    _MK_LOAD_COMMAND_NOT_NULL(load_command, return 0);
+    _MK_LOAD_COMMAND_IS_A(load_command, _mk_load_command_linker_option_class, return 0);
+    
+    size_t current_string_len = 0;
+    const char *current_option_start = mk_load_command_linker_option_get_string(load_command, requested_index, &current_string_len);
+    
+    if (current_option_start != NULL && (current_string_len + 1 /* NULL char */) <= output_len) {
+        memcpy(output, current_option_start, current_string_len + 1 /* NULL char */);
+        return current_string_len;
+    }
+    
+    return 0;
+}
+
+//|++++++++++++++++++++++++++++++++++++|//
+#if __BLOCKS__
+void
+mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
+                                              void (^enumerator)(const char* string, uint32_t index, char* stop))
+{
+    uint32_t nstrings = mk_load_command_linker_option_get_nstrings(load_command);
+    if (nstrings == UINT32_MAX || enumerator == NULL) {
+        return;
+    }
+    
+    for (uint32_t i = 0; i < nstrings; ++i) {
+        const char *string = mk_load_command_linker_option_get_string(load_command, i, NULL);
+        if (string != NULL) {
+            char stop = false;
+            enumerator(string, i, &stop);
+            if (stop) {
+                break;
+            }
+        }
+    }
+}
+#endif

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
@@ -51,7 +51,7 @@ mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint
 //! Iterate over the strings using a block.
 _mk_export void
 mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
-                                                void (^enumerator)(const char* string, uint32_t index, bool* stop));
+                                                void (^enumerator)(const char *string, uint32_t index, bool *stop));
 #endif
 
 //! @} LOAD_COMMANDS !//

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
@@ -51,7 +51,7 @@ mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint
 //! Iterate over the strings using a block.
 _mk_export void
 mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
-                                                void (^enumerator)(const char* string, uint32_t index, char* stop));
+                                                void (^enumerator)(const char* string, uint32_t index, bool* stop));
 #endif
 
 //! @} LOAD_COMMANDS !//

--- a/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
+++ b/libMachO/MachO_ABI/LoadCommands/load_command_linker_option.h
@@ -1,0 +1,59 @@
+//----------------------------------------------------------------------------//
+//|
+//|             MachOKit - A Lightweight Mach-O Parsing Library
+//! @file       load_command_linker_option.h
+//!
+//! @author     Milen Dzhumerov
+//! @copyright  Copyright (c) 2020-2020 Milen Dzhumerov. All rights reserved.
+//|
+//| Permission is hereby granted, free of charge, to any person obtaining a
+//| copy of this software and associated documentation files (the "Software"),
+//| to deal in the Software without restriction, including without limitation
+//| the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//| and/or sell copies of the Software, and to permit persons to whom the
+//| Software is furnished to do so, subject to the following conditions:
+//|
+//| The above copyright notice and this permission notice shall be included
+//| in all copies or substantial portions of the Software.
+//|
+//| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//| OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//| MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//| IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//| CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//| TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//| SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------//
+
+#ifndef _load_command_linker_option_h
+#define _load_command_linker_option_h
+
+//! @addtogroup LOAD_COMMANDS
+//! @{
+//!
+
+//----------------------------------------------------------------------------//
+#pragma mark -  Linker Option
+//! @name       Linker Option
+//----------------------------------------------------------------------------//
+
+_mk_export uint32_t
+mk_load_command_linker_option_id(void);
+
+_mk_export uint32_t
+mk_load_command_linker_option_get_nstrings(mk_load_command_ref load_command);
+
+_mk_export size_t
+mk_load_command_linker_option_copy_string(mk_load_command_ref load_command, uint32_t index, char *output, size_t output_len);
+
+
+#if __BLOCKS__
+//! Iterate over the strings using a block.
+_mk_export void
+mk_load_command_linker_option_enumerate_strings(mk_load_command_ref load_command,
+                                                void (^enumerator)(const char* string, uint32_t index, char* stop));
+#endif
+
+//! @} LOAD_COMMANDS !//
+
+#endif /* _load_command_linker_option_h */

--- a/libMachO/MachO_ABI/load_command.c
+++ b/libMachO/MachO_ABI/load_command.c
@@ -72,7 +72,7 @@ extern const struct _mk_load_command_vtable _mk_load_command_data_in_code_class;
 extern const struct _mk_load_command_vtable _mk_load_command_source_version_class;
 extern const struct _mk_load_command_vtable _mk_load_command_code_sign_drs_class;
 extern const struct _mk_load_command_vtable _mk_load_command_encryption_info_64_class;
-// LC_LINKER_OPTION - Not Implemented
+extern const struct _mk_load_command_vtable _mk_load_command_linker_option_class;
 // LC_LINKER_OPTIMIZATION_HINT - Not Implemented
 extern const struct _mk_load_command_vtable _mk_load_command_version_min_tvos_class;
 extern const struct _mk_load_command_vtable _mk_load_command_version_min_watchos_class;
@@ -127,7 +127,7 @@ const struct _mk_load_command_vtable* _mk_load_command_classes[] = {
     &_mk_load_command_source_version_class,
     &_mk_load_command_code_sign_drs_class,
     &_mk_load_command_encryption_info_64_class,
-    // LC_LINKER_OPTION - Not Implemented
+    &_mk_load_command_linker_option_class,
     // LC_LINKER_OPTIMIZATION_HINT - Not Implemented
     &_mk_load_command_version_min_tvos_class,
     &_mk_load_command_version_min_watchos_class,
@@ -374,9 +374,9 @@ mk_load_command_init(mk_macho_ref image, struct load_command* lc, mk_load_comman
         case LC_ENCRYPTION_INFO_64:
             load_command->vtable = &_mk_load_command_encryption_info_64_class;
             break;
-        //case LC_LINKER_OPTION: - Not implemented
-        //  load_command->vtable =
-        //  break;
+        case LC_LINKER_OPTION:
+            load_command->vtable = &_mk_load_command_linker_option_class;
+            break;
         //case LC_LINKER_OPTIMIZATION_HINT: - Not implemented
         //  load_command->vtable =
         //  break;

--- a/libMachO/MachO_ABI/load_command.h
+++ b/libMachO/MachO_ABI/load_command.h
@@ -112,6 +112,7 @@ _mk_export intptr_t mk_load_command_type;
 #include "load_command_build_version.h"
 #include "load_command_dyld_exports_trie.h"
 #include "load_command_dyld_chained_fixups.h"
+#include "load_command_linker_option.h"
 
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
Adds support for reading `LC_LINKER_OPTION` load commands which can be founder in object files. The PR is split into two commits, the first adds the required C functions and the second one adds the `MKLoadCommand` subclass.